### PR TITLE
Just use #undef with no #ifdef

### DIFF
--- a/Marlin/pins_AZTEEG_X1.h
+++ b/Marlin/pins_AZTEEG_X1.h
@@ -28,8 +28,5 @@
 
 #include "pins_SANGUINOLOLU_11.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Azteeg X1"

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Azteeg X3"
 
 //LCD Pins//

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Azteeg X3 Pro"
 
 #undef FAN_PIN

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "2PrintBeta Due"
 
 #undef TEMP_0_PIN

--- a/Marlin/pins_BQ_ZUM_MEGA_3D.h
+++ b/Marlin/pins_BQ_ZUM_MEGA_3D.h
@@ -30,10 +30,7 @@
 
 #include "pins_RAMPS_13.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "ZUM Mega 3D"
 
 #undef X_MAX_PIN

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Felix 2.0+"
 
 #undef HEATER_1_PIN

--- a/Marlin/pins_GEN6_DELUXE.h
+++ b/Marlin/pins_GEN6_DELUXE.h
@@ -26,8 +26,5 @@
 
 #include "pins_GEN6.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Gen6 Deluxe"

--- a/Marlin/pins_GEN7_13.h
+++ b/Marlin/pins_GEN7_13.h
@@ -29,8 +29,5 @@
 
 #include "pins_GEN7_12.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Gen7 v1.3"

--- a/Marlin/pins_K8200.h
+++ b/Marlin/pins_K8200.h
@@ -33,8 +33,5 @@
 #undef  DEFAULT_SOURCE_CODE_URL
 #define DEFAULT_SOURCE_CODE_URL "https://github.com/CONSULitAS/Marlin-K8200"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Velleman K8200"

--- a/Marlin/pins_MELZI.h
+++ b/Marlin/pins_MELZI.h
@@ -32,8 +32,5 @@
 
 #include "pins_SANGUINOLOLU_11.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Melzi"

--- a/Marlin/pins_MELZI_MAKR3D.h
+++ b/Marlin/pins_MELZI_MAKR3D.h
@@ -34,8 +34,5 @@
 
 #include "pins_SANGUINOLOLU_11.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Melzi ATmega1284"

--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -31,10 +31,7 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "MKS > v1.3"
 
 #undef HEATER_1_PIN

--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "MKS BASE 1.0"
 
 #undef HEATER_1_PIN

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -37,8 +37,5 @@
 
 #include "pins_RAMPS_14.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "RAMPS 1.3"

--- a/Marlin/pins_RAMPS_13_EFB.h
+++ b/Marlin/pins_RAMPS_13_EFB.h
@@ -30,8 +30,5 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "RAMPS 1.3 EFB"

--- a/Marlin/pins_RAMPS_14_EFB.h
+++ b/Marlin/pins_RAMPS_14_EFB.h
@@ -30,8 +30,5 @@
 
 #include "pins_RAMPS_14.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "RAMPS 1.4 EFB"

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "RigidBoard"
 
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)

--- a/Marlin/pins_RIGIDBOARD_V2.h
+++ b/Marlin/pins_RIGIDBOARD_V2.h
@@ -26,10 +26,7 @@
 
 #include "pins_RIGIDBOARD.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "RigidBoard V2"
 
 // I2C based DAC like on the Printrboard REVF

--- a/Marlin/pins_SAINSMART_2IN1.h
+++ b/Marlin/pins_SAINSMART_2IN1.h
@@ -26,10 +26,7 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME          "Sainsmart"
 
 #undef FAN_PIN

--- a/Marlin/pins_SANGUINOLOLU_12.h
+++ b/Marlin/pins_SANGUINOLOLU_12.h
@@ -40,8 +40,5 @@
 
 #include "pins_SANGUINOLOLU_11.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "Sanguinololu 1.2"

--- a/Marlin/pins_STB_11.h
+++ b/Marlin/pins_STB_11.h
@@ -32,8 +32,5 @@
 
 #include "pins_SANGUINOLOLU_11.h"
 
-#ifdef BOARD_NAME
-  #undef BOARD_NAME
-#endif
-
+#undef BOARD_NAME
 #define BOARD_NAME "STB V1.1"


### PR DESCRIPTION
Since `#undef` has no effect when something is undefined there's no need to wrap it in `#ifdef`.
