### PR TITLE
Use STATIC_ITEM for static text

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1901,6 +1901,7 @@ static void lcd_status_screen() {
      *
      */
     static void lcd_info_menu() {
+      if (LCD_CLICKED) lcd_return_to_status();
       START_MENU();
       STATIC_ITEM(MSG_MARLIN);               // Marlin
       STATIC_ITEM(SHORT_BUILD_VERSION);      // x.x.x-Branch


### PR DESCRIPTION
The PR #3662 adds a `STATIC_ITEM` macro to `ultralcd.cpp` that works within the menu system to display a non-interactive line of static text. This gains us 2 spaces since there is no cursor display. The cursor still exists, so you can scroll the display. The cursor cannot move above the 4th display line (on a 4-line display). Thus, if you scroll to the top, there is no "dead spot" where it will not scroll.

This also makes the feature optional, and disabled by default.

Since static items are non-interactive, we explicitly check for a click to return to status.
