### PR TITLE
Patch for STATIC_ITEM_VAR ability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,11 +161,11 @@ script:
   - opt_set MOTHERBOARD BOARD_MINIRAMBO
   - build_marlin
   #
-  # Enable FILAMENTCHANGEENABLE
+  # Test FILAMENTCHANGEENABLE and LCD_INFO_MENU
   #
   - restore_configs
   - opt_enable ULTIMAKERCONTROLLER
-  - opt_enable_adv FILAMENTCHANGEENABLE
+  - opt_enable_adv FILAMENTCHANGEENABLE LCD_INFO_MENU
   - build_marlin
   #
   # Enable filament sensor

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -56,35 +56,21 @@
  * Marlin release, version and default string
  */
 #ifndef SHORT_BUILD_VERSION
-  #error "SHORT_BUILD_VERSION Information must be specified"
-#endif
-
-#ifndef DETAILED_BUILD_VERSION
-  #error "BUILD_VERSION Information must be specified"
-#endif
-
-#ifndef STRING_DISTRIBUTION_DATE
-  #error "STRING_DISTRIBUTION_DATE Information must be specified"
-#endif
-
-#ifndef PROTOCOL_VERSION
-  #error "PROTOCOL_VERSION Information must be specified"
-#endif
-
-#ifndef MACHINE_NAME
-  #error "MACHINE_NAME Information must be specified"
-#endif
-
-#ifndef SOURCE_CODE_URL
-  #error "SOURCE_CODE_URL Information must be specified"
-#endif
-
-#ifndef DEFAULT_MACHINE_UUID
-  #error "DEFAULT_MACHINE_UUID Information must be specified"
-#endif
-
-#ifndef WEBSITE_URL
-  #error "WEBSITE_URL Information must be specified"
+  #error "SHORT_BUILD_VERSION must be specified."
+#elif !defined(DETAILED_BUILD_VERSION)
+  #error "BUILD_VERSION must be specified."
+#elif !defined(STRING_DISTRIBUTION_DATE)
+  #error "STRING_DISTRIBUTION_DATE must be specified."
+#elif !defined(PROTOCOL_VERSION)
+  #error "PROTOCOL_VERSION must be specified."
+#elif !defined(MACHINE_NAME)
+  #error "MACHINE_NAME must be specified."
+#elif !defined(SOURCE_CODE_URL)
+  #error "SOURCE_CODE_URL must be specified."
+#elif !defined(DEFAULT_MACHINE_UUID)
+  #error "DEFAULT_MACHINE_UUID must be specified."
+#elif !defined(WEBSITE_URL)
+  #error "WEBSITE_URL must be specified."
 #endif
 
 /**

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -473,21 +473,29 @@ static void lcd_implementation_mark_as_selected(uint8_t row, bool isSelected) {
   u8g.setPrintPos((START_ROW) * (DOG_CHAR_WIDTH), (row + 1) * (DOG_CHAR_HEIGHT));
 }
 
-static void lcd_implementation_drawmenu_static(uint8_t row, const char* pstr, bool center=true) {
-  char c;
-  uint8_t n = LCD_WIDTH;
-  u8g.setPrintPos(0, (row + 1) * (DOG_CHAR_HEIGHT));
-  u8g.setColorIndex(1); // normal text
-  if (center) {
-    int8_t pad = (LCD_WIDTH - lcd_strlen_P(pstr)) / 2;
-    while (--pad >= 0) { lcd_print(' '); n--; }
+#if ENABLED(LCD_INFO_MENU)
+
+  static void lcd_implementation_drawmenu_static(uint8_t row, const char* pstr, const char* valstr=NULL, bool center=false) {
+    char c;
+    int8_t n = LCD_WIDTH;
+    u8g.setPrintPos(0, (row + 1) * (DOG_CHAR_HEIGHT));
+    u8g.setColorIndex(1); // normal text
+    if (center) {
+      int8_t pad = (LCD_WIDTH - lcd_strlen_P(pstr)) / 2;
+      while (--pad >= 0) { lcd_print(' '); n--; }
+    }
+    while (c = pgm_read_byte(pstr)) {
+      n -= lcd_print(c);
+      pstr++;
+    }
+    if (valstr) {
+      lcd_print(valstr);
+      n -= lcd_strlen(valstr);
+    }
+    while (n-- > 0) lcd_print(' ');
   }
-  while (c = pgm_read_byte(pstr)) {
-    n -= lcd_print(c);
-    pstr++;
-  }
-  while (n--) lcd_print(' ');
-}
+
+#endif // LCD_INFO_MENU
 
 static void lcd_implementation_drawmenu_generic(bool isSelected, uint8_t row, const char* pstr, char pre_char, char post_char) {
   UNUSED(pstr);

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -523,6 +523,9 @@
 #ifndef MSG_INFO_MENU
   #define MSG_INFO_MENU                       "About Printer"
 #endif
+#ifndef MSG_INFO_PRINTER_MENU
+  #define MSG_INFO_PRINTER_MENU               "Printer Info"
+#endif
 #ifndef MSG_INFO_STATS_MENU
   #define MSG_INFO_STATS_MENU                 "Printer Stats"
 #endif

--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -88,7 +88,7 @@ void PrintCounter::showStats() {
   SERIAL_ECHO(this->data.totalPrints - this->data.finishedPrints
     - ((this->isRunning() || this->isPaused()) ? 1 : 0)); // Removes 1 from failures with an active counter
 
-  uint32_t t = this->data.printTime /60;
+  uint32_t t = this->data.printTime / 60;
   SERIAL_ECHOPGM(", Total print time: ");
   SERIAL_ECHO(t / 60);
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -271,16 +271,6 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     } \
     _menuItemNr++
 
-  // Same as STATIC_ITEM, but can display variables. Do not use for text strings.
-  #define STATIC_ITEM_VAR(label, args...) \
-    if (_menuItemNr == _lineNr) { \
-      if (encoderLine == _menuItemNr && _menuItemNr < LCD_HEIGHT - 1) \
-        encoderPosition += ENCODER_STEPS_PER_MENU_ITEM; \
-      if (lcdDrawUpdate) \
-        lcd_implementation_drawmenu_static(_drawLineNr, label, ## args); \
-    } \
-    _menuItemNr++
-
   #if ENABLED(ENCODER_RATE_MULTIPLIER)
 
     //#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
@@ -1914,10 +1904,11 @@ static void lcd_status_screen() {
   #endif //SDSUPPORT
 
   #if ENABLED(LCD_INFO_MENU)
+
     #if ENABLED(PRINTCOUNTER)
       /**
        *
-       * Printer Info > Stastics submenu
+       * About Printer > Stastics submenu
        *
        */
       static void lcd_info_stats_menu() {
@@ -1925,28 +1916,21 @@ static void lcd_status_screen() {
         print_job_counter.loadStats();
         printStatistics stats = print_job_counter.getStats();
 
-        char totalPrints[18];
-        itoa(stats.totalPrints, totalPrints, 10);
-        char finishedPrints[18];
-        itoa(stats.finishedPrints, finishedPrints, 10);
-        char printTime[18];
-        itoa(stats.printTime, printTime, 10);
+        char printTime[6];
+        sprintf(printTime, "%02d:%02d", stats.printTime / 60, stats.printTime % 60);
 
         if (LCD_CLICKED) lcd_goto_previous_menu(true);
         START_MENU();
-        STATIC_ITEM(MSG_INFO_TOTAL_PRINTS ": ");    // Total Prints:
-        STATIC_ITEM_VAR(totalPrints);               // 999
-        STATIC_ITEM(MSG_INFO_FINISHED_PRINTS ": "); // Finished Prints:
-        STATIC_ITEM_VAR(finishedPrints);            // 666
-        STATIC_ITEM(MSG_INFO_PRINT_TIME ": ");      // Total Print Time:
-        STATIC_ITEM_VAR(printTime);                 // 123456
+        STATIC_ITEM(MSG_INFO_TOTAL_PRINTS ": ", itostr3left(stats.totalPrints));       // Total Prints: 999
+        STATIC_ITEM(MSG_INFO_FINISHED_PRINTS ": ", itostr3left(stats.finishedPrints)); // Finished Prints: 666
+        STATIC_ITEM(MSG_INFO_PRINT_TIME ": ", printTime);                              // Total Print Time: 123456
         END_MENU();
       }
-    #endif
-  
+    #endif // PRINTCOUNTER
+
     /**
      *
-     * Printer Info > Thermistors
+     * About Printer > Thermistors
      *
      */
     static void lcd_info_thermistors_menu() {
@@ -1984,7 +1968,7 @@ static void lcd_status_screen() {
         STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_3_MINTEMP));
         STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_3_MAXTEMP));
       #endif
-    
+
       #if TEMP_SENSOR_BED != 0
         #undef THERMISTOR_ID
         #define THERMISTOR_ID TEMP_SENSOR_BED
@@ -1998,7 +1982,7 @@ static void lcd_status_screen() {
 
     /**
      *
-     * Printer Info > Board Info
+     * About Printer > Board Info
      *
      */
     static void lcd_info_board_menu() {
@@ -2019,23 +2003,32 @@ static void lcd_status_screen() {
 
     /**
      *
-     * "Printer Info" submenu
+     * About Printer > Printer Info
      *
      */
-    static void lcd_info_menu() {
-      START_MENU();
-      MENU_ITEM(back, MSG_INFO_MENU);
+    static void lcd_info_printer_menu() {
+      if (LCD_CLICKED) lcd_goto_previous_menu(true);
       STATIC_ITEM(MSG_MARLIN);                                   // Marlin
       STATIC_ITEM(SHORT_BUILD_VERSION);                          // x.x.x-Branch
       STATIC_ITEM(STRING_DISTRIBUTION_DATE);                     // YYYY-MM-DD HH:MM
       STATIC_ITEM(MACHINE_NAME);                                 // My3DPrinter
       STATIC_ITEM(WEBSITE_URL);                                  // www.my3dprinter.com
       STATIC_ITEM(MSG_INFO_EXTRUDERS ": " STRINGIFY(EXTRUDERS)); // Extruders: 2
+    }
 
-      MENU_ITEM(submenu, MSG_INFO_BOARD_MENU, lcd_info_board_menu);            // Board Info ->
-      MENU_ITEM(submenu, MSG_INFO_THERMISTOR_MENU, lcd_info_thermistors_menu); // Thermistors ->
+    /**
+     *
+     * "About Printer" submenu
+     *
+     */
+    static void lcd_info_menu() {
+      START_MENU();
+      MENU_ITEM(back, MSG_MAIN);
+      MENU_ITEM(submenu, MSG_INFO_PRINTER_MENU, lcd_info_printer_menu);        // Printer Info >
+      MENU_ITEM(submenu, MSG_INFO_BOARD_MENU, lcd_info_board_menu);            // Board Info >
+      MENU_ITEM(submenu, MSG_INFO_THERMISTOR_MENU, lcd_info_thermistors_menu); // Thermistors >
       #if ENABLED(PRINTCOUNTER)
-        MENU_ITEM(submenu, MSG_INFO_STATS_MENU, lcd_info_stats_menu);          // Printer Statistics ->
+        MENU_ITEM(submenu, MSG_INFO_STATS_MENU, lcd_info_stats_menu);          // Printer Statistics >
       #endif
       END_MENU();
     }
@@ -2744,7 +2737,6 @@ char *ftostr4sign(const float& x) { return itostr4sign((int)x); }
 
 // Convert unsigned int to string with 12 format
 char* itostr2(const uint8_t& x) {
-  //sprintf(conv,"%5.1f",x);
   int xx = x;
   conv[0] = DIGIMOD(xx / 10);
   conv[1] = DIGIMOD(xx);

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -815,20 +815,28 @@ static void lcd_implementation_status_screen() {
   lcd_print(lcd_status_message);
 }
 
-static void lcd_implementation_drawmenu_static(uint8_t row, const char* pstr, bool center=true) {
-  char c;
-  uint8_t n = LCD_WIDTH;
-  lcd.setCursor(0, row);
-  if (center) {
-    int8_t pad = (LCD_WIDTH - lcd_strlen_P(pstr)) / 2;
-    while (--pad >= 0) { lcd.print(' '); n--; }
+#if ENABLED(LCD_INFO_MENU)
+
+  static void lcd_implementation_drawmenu_static(uint8_t row, const char* pstr, const char *valstr=NULL, bool center=true) {
+    char c;
+    int8_t n = LCD_WIDTH;
+    lcd.setCursor(0, row);
+    if (center) {
+      int8_t pad = (LCD_WIDTH - lcd_strlen_P(pstr)) / 2;
+      while (--pad >= 0) { lcd.print(' '); n--; }
+    }
+    while ((c = pgm_read_byte(pstr)) && n > 0) {
+      n -= lcd_print(c);
+      pstr++;
+    }
+    if (valstr) {
+      lcd_print(valstr);
+      n -= lcd_strlen(valstr);
+    }
+    while (n-- > 0) lcd.print(' ');
   }
-  while ((c = pgm_read_byte(pstr)) && n > 0) {
-    n -= lcd_print(c);
-    pstr++;
-  }
-  while (n--) lcd.print(' ');
-}
+
+#endif // LCD_INFO_MENU
 
 static void lcd_implementation_drawmenu_generic(bool sel, uint8_t row, const char* pstr, char pre_char, char post_char) {
   char c;


### PR DESCRIPTION
- Add an extra (optional) string argument to `lcd_implementation_drawmenu_static`.
- `lcd_implementation_drawmenu_static` prints left-justified by default.
- Make `lcd_implementation_drawmenu_static` contingent on `LCD_INFO_MENU`.
- Pass an extra value in `STATIC_ITEM` to display values.
- Can't mix `STATIC_ITEM` and `MENU_ITEM`, so make `Printer Info` a submenu of `About Printer`.
